### PR TITLE
Fix api conflict for DynamicProperty.of method for null value.

### DIFF
--- a/dynamic-property-api/src/main/java/ru/fix/dynamic/property/api/DelegatedProperty.java
+++ b/dynamic-property-api/src/main/java/ru/fix/dynamic/property/api/DelegatedProperty.java
@@ -1,5 +1,6 @@
 package ru.fix.dynamic.property.api;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -11,11 +12,12 @@ import java.util.function.Supplier;
  * If you need a DynamicProperty with full listener support backed up by {@link Supplier} use DynamicPropertyPoller
  * @see ru.fix.dynamic.property.polling.DynamicPropertyPoller
  */
-public class SuppliedProperty<T> implements DynamicProperty<T> {
+public class DelegatedProperty<T> implements DynamicProperty<T> {
 
     private final Supplier<T> supplier;
 
-    public SuppliedProperty(Supplier<T> supplier) {
+    public DelegatedProperty(Supplier<T> supplier) {
+        Objects.requireNonNull(supplier);
         this.supplier = supplier;
     }
 

--- a/dynamic-property-api/src/main/java/ru/fix/dynamic/property/api/DynamicProperty.java
+++ b/dynamic-property-api/src/main/java/ru/fix/dynamic/property/api/DynamicProperty.java
@@ -146,18 +146,18 @@ public interface DynamicProperty<T> extends AutoCloseable {
     }
 
     /**
+     * Return DynamicProperty proxy that delegates {@link DynamicProperty#get()}  to given supplier. <br>
+     * <br>
      * Be aware that DynamicProperty created this way
-     * does not notify listeners through {@link java.beans.PropertyChangeListener}
-     * @return DynamicProperty proxy. All requests to {@link DynamicProperty#get()}
-     * will be delegated to {@link Supplier#get()} method of given supplier.
+     * does not notify listeners through {@link java.beans.PropertyChangeListener} <br>
+     * Here is an example of inappropriate usage of delegated property:
      * <pre>{@code
-     *
      * class Foo(supplier: Supplier<String>){
-     *     // will break since bar is actually needs listener support
-     *     val bar = Bar(DynamicProperty.of(supplier))
+     *     // will not work correctly since bar is actually needs listener support
+     *     val bar = Bar(DynamicProperty.delegated(supplier))
      *
      *     // will work correctly
-     *     val baz = Baz(DynamicProperty.of(supplier))
+     *     val baz = Baz(DynamicProperty.delegated(supplier))
      * }
      *
      * class Bar(property: DynamicProperty<String>){
@@ -173,10 +173,11 @@ public interface DynamicProperty<T> extends AutoCloseable {
      * }</pre>
      * If you need a DynamicProperty with full listeners support backed up by {@link Supplier}
      * use DynamicPropertyPoller instead
+     * @return DynamicProperty proxy.
      * @see ru.fix.dynamic.property.polling.DynamicPropertyPoller
      */
-    static <T> DynamicProperty<T> of(Supplier<T> supplier) {
-        return new SuppliedProperty<>(supplier);
+    static <T> DynamicProperty<T> delegated(Supplier<T> supplier) {
+        return new DelegatedProperty<>(supplier);
     }
 
     /**

--- a/dynamic-property-api/src/test/kotlin/ru/fix/dynamic/property/api/DynamicPropertyTest.kt
+++ b/dynamic-property-api/src/test/kotlin/ru/fix/dynamic/property/api/DynamicPropertyTest.kt
@@ -2,6 +2,7 @@ package ru.fix.dynamic.property.api
 
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicReference
 
@@ -81,5 +82,17 @@ class DynamicPropertyTest {
 
         second.set("42")
         assertEquals("hi42", combine.get())
+    }
+
+    @Test
+    fun `delegated property`() {
+        val property = DynamicProperty.delegated { 12 }
+        assertEquals(12, property.get())
+    }
+
+    @Test
+    fun `constant property of null`() {
+        val property = DynamicProperty.of<String>(null)
+        assertNull(property.get())
     }
 }

--- a/dynamic-property-spring/src/test/java/ru/fix/dynamic/property/spring/InjectingPropertyIdBySprtingTest.java
+++ b/dynamic-property-spring/src/test/java/ru/fix/dynamic/property/spring/InjectingPropertyIdBySprtingTest.java
@@ -18,7 +18,7 @@ import ru.fix.dynamic.property.spring.config.DynamicPropertyConfig;
 import ru.fix.dynamic.property.std.source.InMemoryPropertySource;
 import ru.fix.stdlib.concurrency.threads.ReferenceCleaner;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 /**
@@ -41,6 +41,9 @@ public class InjectingPropertyIdBySprtingTest {
         public DynamicProperty<String> getStatus() {
             return status;
         }
+
+        @PropertyId("nullable.property")
+        private DynamicProperty<String> nullableProperty = DynamicProperty.of(null);
     }
 
     @Configuration
@@ -69,4 +72,9 @@ public class InjectingPropertyIdBySprtingTest {
         assertEquals("Biribidjan", propertyContainer.getCity().get());
     }
 
+    @Test
+    public void nullable_property_initialized_by_default_with_null(){
+        assertNotNull(propertyContainer.nullableProperty);
+        assertNull(propertyContainer.nullableProperty.get());
+    }
 }


### PR DESCRIPTION
DynamicProperty.of(null)  leads to a bug: Compiler prefer to use DynamicProperyt.of(Supplier) over DynamicProperty.of(value).  This is not that user expects from this api.   
Chnage: DynamicProperyt.of(Supplier) renamed to DynamicProperyt.delegated(Supplier)  