### PR TITLE
jdk8 compartible version of dynamic-property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,9 +181,14 @@ subprojects {
     }
 
     tasks {
+        withType<JavaCompile> {
+            sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+            targetCompatibility = JavaVersion.VERSION_1_8.toString()
+        }
+
         withType<KotlinCompile> {
             kotlinOptions {
-                jvmTarget = "1.8"
+                jvmTarget = JavaVersion.VERSION_1_8.toString()
             }
         }
         withType<Test> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -19,7 +19,7 @@ object Vers {
 
     const val log4j =  "2.12.0"
 
-    const val jfix_stdlib = "1.0.60"
+    const val jfix_stdlib = "2.0.15-jdk8"
 }
 
 object Libs {
@@ -40,6 +40,7 @@ object Libs {
 
     val jfix_stdlib_concurrency = "ru.fix:jfix-stdlib-concurrency:${Vers.jfix_stdlib}"
     val jfix_stdlib_files = "ru.fix:jfix-stdlib-files:${Vers.jfix_stdlib}"
+    val jfix_stdlib_reference = "ru.fix:jfix-stdlib-reference:${Vers.jfix_stdlib}"
 
     const val slf4j_api = "org.slf4j:slf4j-api:${Vers.sl4j}"
     const val slf4j_simple = "org.slf4j:slf4j-simple:${Vers.sl4j}"

--- a/dynamic-property-std-source/build.gradle.kts
+++ b/dynamic-property-std-source/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 
     implementation(Libs.kotlin_stdlib)
     implementation(Libs.kotlin_jdk8)
-    implementation(Libs.jfix_stdlib_concurrency){
+    implementation(Libs.jfix_stdlib_reference){
         exclude("ru.fix", "dynamic-property-api")
     }
     implementation(Libs.jfix_stdlib_files){

--- a/dynamic-property-std-source/src/main/kotlin/ru/fix/dynamic/property/std/source/AbstractPropertySource.kt
+++ b/dynamic-property-std-source/src/main/kotlin/ru/fix/dynamic/property/std/source/AbstractPropertySource.kt
@@ -5,8 +5,8 @@ import ru.fix.dynamic.property.api.source.DynamicPropertySource
 import ru.fix.dynamic.property.api.marshaller.DynamicPropertyMarshaller
 import ru.fix.dynamic.property.api.source.OptionalDefaultValue
 import ru.fix.dynamic.property.api.source.DynamicPropertyValueNotFoundException
-import ru.fix.stdlib.concurrency.threads.CleanableWeakReference
-import ru.fix.stdlib.concurrency.threads.ReferenceCleaner
+import ru.fix.stdlib.reference.CleanableWeakReference
+import ru.fix.stdlib.reference.ReferenceCleaner
 import java.util.concurrent.ConcurrentHashMap
 
 

--- a/dynamic-property-std-source/src/main/kotlin/ru/fix/dynamic/property/std/source/FilePropertySource.kt
+++ b/dynamic-property-std-source/src/main/kotlin/ru/fix/dynamic/property/std/source/FilePropertySource.kt
@@ -4,8 +4,8 @@ import ru.fix.dynamic.property.api.DynamicProperty
 import ru.fix.dynamic.property.api.marshaller.DynamicPropertyMarshaller
 import ru.fix.dynamic.property.api.source.DynamicPropertySource
 import ru.fix.dynamic.property.api.source.OptionalDefaultValue
-import ru.fix.stdlib.concurrency.threads.ReferenceCleaner
 import ru.fix.stdlib.files.FileWatcher
+import ru.fix.stdlib.reference.ReferenceCleaner
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path

--- a/dynamic-property-std-source/src/main/kotlin/ru/fix/dynamic/property/std/source/InMemoryPropertySource.kt
+++ b/dynamic-property-std-source/src/main/kotlin/ru/fix/dynamic/property/std/source/InMemoryPropertySource.kt
@@ -1,7 +1,7 @@
 package ru.fix.dynamic.property.std.source
 
 import ru.fix.dynamic.property.api.marshaller.DynamicPropertyMarshaller
-import ru.fix.stdlib.concurrency.threads.ReferenceCleaner
+import ru.fix.stdlib.reference.ReferenceCleaner
 
 /**
  * Keep properties in memory.

--- a/dynamic-property-zk/build.gradle.kts
+++ b/dynamic-property-zk/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 
     implementation(Libs.log4j_kotlin)
     implementation(Libs.curator_recipes)
-    implementation(Libs.jfix_stdlib_concurrency){
+    implementation(Libs.jfix_stdlib_reference){
         exclude("ru.fix", "dynamic-property-api")
     }
     implementation(project(Projs.dynamic_property_jackson.dependency))

--- a/dynamic-property-zk/src/main/kotlin/ru/fix/dynamic/property/zk/ZkDynamicPropertySource.kt
+++ b/dynamic-property-zk/src/main/kotlin/ru/fix/dynamic/property/zk/ZkDynamicPropertySource.kt
@@ -9,7 +9,7 @@ import org.apache.curator.framework.recipes.cache.TreeCacheListener
 import org.apache.logging.log4j.kotlin.Logging
 import ru.fix.dynamic.property.api.marshaller.DynamicPropertyMarshaller
 import ru.fix.dynamic.property.std.source.AbstractPropertySource
-import ru.fix.stdlib.concurrency.threads.ReferenceCleaner
+import ru.fix.stdlib.reference.ReferenceCleaner
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.*


### PR DESCRIPTION
Make dynamic-property compatible with jdk8. Will build on jdk11 with target bytecode 52 version (java 8 bytecode)