### PR TITLE
ComposableDynamicPropertyMarshaller improvements 

### DIFF
--- a/dynamic-property-api/src/main/java/ru/fix/dynamic/property/api/marshaller/exception/DynamicPropertySerializationException.java
+++ b/dynamic-property-api/src/main/java/ru/fix/dynamic/property/api/marshaller/exception/DynamicPropertySerializationException.java
@@ -5,6 +5,10 @@ package ru.fix.dynamic.property.api.marshaller.exception;
  */
 public class DynamicPropertySerializationException extends RuntimeException {
 
+    public DynamicPropertySerializationException(String message) {
+        super(message);
+    }
+
     public DynamicPropertySerializationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/ComposableDynamicPropertyMarshaller.java
+++ b/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/ComposableDynamicPropertyMarshaller.java
@@ -3,11 +3,9 @@ package ru.fix.dynamic.property.jackson;
 import ru.fix.dynamic.property.api.marshaller.DynamicPropertyMarshaller;
 import ru.fix.dynamic.property.api.marshaller.exception.DynamicPropertySerializationException;
 import ru.fix.dynamic.property.jackson.serializer.composable.ComposableSerializer;
+import ru.fix.dynamic.property.jackson.serializer.composable.exception.NotFoundSerializerException;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 
 /**
@@ -15,13 +13,10 @@ import java.util.Optional;
  */
 public class ComposableDynamicPropertyMarshaller implements DynamicPropertyMarshaller {
 
-    private final List<ComposableSerializer> serializers;
-    private final ComposableSerializer defaultSerializer;
+    private final Set<ComposableSerializer> serializers;
 
-    ComposableDynamicPropertyMarshaller(List<ComposableSerializer> serializers,
-                                        ComposableSerializer defaultSerializer) {
-        this.serializers = Collections.unmodifiableList(serializers);
-        this.defaultSerializer = defaultSerializer;
+    ComposableDynamicPropertyMarshaller(Set<ComposableSerializer> serializers) {
+        this.serializers = Collections.unmodifiableSet(serializers);
     }
 
     @Override
@@ -34,11 +29,13 @@ public class ComposableDynamicPropertyMarshaller implements DynamicPropertyMarsh
                     return result.get();
                 }
             }
-            return defaultSerializer.serialize(marshalledObject).get();
         } catch (Exception e) {
             throw new DynamicPropertySerializationException(
                     "Failed to serialize. Type: " + marshalledObject.getClass() + ". Instance: " + marshalledObject, e);
         }
+        throw new NotFoundSerializerException(
+                "Not found serializer for object. Type: " + marshalledObject.getClass() + ". Instance: "
+                        + marshalledObject);
     }
 
     @Override
@@ -52,10 +49,11 @@ public class ComposableDynamicPropertyMarshaller implements DynamicPropertyMarsh
                     return result.get();
                 }
             }
-            return defaultSerializer.deserialize(rawString, type).get();
         } catch (Exception e) {
             throw new DynamicPropertySerializationException(
                     "Failed to deserialize. Type: " + type + ". From " + rawString, e);
         }
+        throw new NotFoundSerializerException(
+                "Not found serializer for object. Type: " + type + ". From " + rawString);
     }
 }

--- a/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/ComposableDynamicPropertyMarshaller.java
+++ b/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/ComposableDynamicPropertyMarshaller.java
@@ -9,7 +9,7 @@ import java.util.*;
 
 
 /**
- * Implementation of {@link DynamicPropertyMarshaller} which provides serialization and deserialization by Jacskon.
+ * Implementation of {@link DynamicPropertyMarshaller} which provides serialization and deserialization by Jackson.
  */
 public class ComposableDynamicPropertyMarshaller implements DynamicPropertyMarshaller {
 

--- a/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/MarshallerBuilder.java
+++ b/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/MarshallerBuilder.java
@@ -5,12 +5,17 @@ import ru.fix.dynamic.property.jackson.serializer.composable.ComposableSerialize
 import ru.fix.dynamic.property.jackson.serializer.composable.JacksonSerializer;
 import ru.fix.dynamic.property.jackson.serializer.composable.StdSerializer;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
+/**
+ * Builder of {@link ComposableDynamicPropertyMarshaller} that allows to add custom serializers/
+ * Builder add {@link StdSerializer} as the first serializer and {@link JacksonSerializer} as the last serializer.
+ */
 public class MarshallerBuilder {
 
-    private final List<ComposableSerializer> serializers = new LinkedList<>();
+    private final Set<ComposableSerializer> serializers = new LinkedHashSet<>();
 
     private MarshallerBuilder() {
         serializers.add(new StdSerializer());
@@ -20,17 +25,26 @@ public class MarshallerBuilder {
         return new MarshallerBuilder();
     }
 
+    /**
+     * @return marshaller without custom serializers
+     */
+    public static DynamicPropertyMarshaller createDefault() {
+        return newBuilder().build();
+    }
+
     public MarshallerBuilder addSerializer(ComposableSerializer marshaller) {
         serializers.add(marshaller);
         return this;
     }
 
-    public MarshallerBuilder addSerializers(List<ComposableSerializer> marshallerList) {
+    public MarshallerBuilder addSerializers(Collection<ComposableSerializer> marshallerList) {
         serializers.addAll(marshallerList);
         return this;
     }
 
     public DynamicPropertyMarshaller build() {
-        return new ComposableDynamicPropertyMarshaller(serializers, new JacksonSerializer());
+        serializers.add(new JacksonSerializer());
+        return new ComposableDynamicPropertyMarshaller(serializers);
     }
+
 }

--- a/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/serializer/composable/ComposableSerializer.java
+++ b/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/serializer/composable/ComposableSerializer.java
@@ -1,6 +1,5 @@
 package ru.fix.dynamic.property.jackson.serializer.composable;
 
-import java.io.IOException;
 import java.util.Optional;
 
 public interface ComposableSerializer {
@@ -10,12 +9,12 @@ public interface ComposableSerializer {
      *
      * @return empty if the current serializer is not suitable for given type
      */
-    Optional<String> serialize(Object marshalledObject) throws IOException;
+    Optional<String> serialize(Object marshalledObject);
 
     /**
      * Deserialize object from string value
      *
      * @return empty if the current serializer is not suitable for given type
      */
-    <T> Optional<T> deserialize(String rawString, Class<T> clazz) throws IOException;
+    <T> Optional<T> deserialize(String rawString, Class<T> clazz);
 }

--- a/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/serializer/composable/exception/JacksonSerializeException.java
+++ b/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/serializer/composable/exception/JacksonSerializeException.java
@@ -1,0 +1,8 @@
+package ru.fix.dynamic.property.jackson.serializer.composable.exception;
+
+public class JacksonSerializeException extends RuntimeException {
+
+    public JacksonSerializeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/serializer/composable/exception/NotFoundSerializerException.java
+++ b/dynamic-property-jackson/src/main/java/ru/fix/dynamic/property/jackson/serializer/composable/exception/NotFoundSerializerException.java
@@ -1,0 +1,10 @@
+package ru.fix.dynamic.property.jackson.serializer.composable.exception;
+
+import ru.fix.dynamic.property.api.marshaller.exception.DynamicPropertySerializationException;
+
+public class NotFoundSerializerException extends DynamicPropertySerializationException {
+
+    public NotFoundSerializerException(String message) {
+        super(message);
+    }
+}

--- a/dynamic-property-jackson/src/test/java/ru/fix/dynamic/property/jackson/ComposableDynamicPropertyMarshallerTest.java
+++ b/dynamic-property-jackson/src/test/java/ru/fix/dynamic/property/jackson/ComposableDynamicPropertyMarshallerTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ComposableDynamicPropertyMarshallerTest {
 
-    private final DynamicPropertyMarshaller marshaller = MarshallerBuilder.newBuilder().build();
+    private final DynamicPropertyMarshaller marshaller = MarshallerBuilder.createDefault();
 
     @Test
     public void marshallPrimitiveTypes() {

--- a/dynamic-property-spring/src/test/java/ru/fix/dynamic/property/spring/DynamicPropertyAwareBeanPostProcessorTest.java
+++ b/dynamic-property-spring/src/test/java/ru/fix/dynamic/property/spring/DynamicPropertyAwareBeanPostProcessorTest.java
@@ -26,7 +26,7 @@ class DynamicPropertyAwareBeanPostProcessorTest {
     @BeforeEach
     void createSourceAndProcessor() {
         propertySource = new InMemoryPropertySource(
-                MarshallerBuilder.newBuilder().build(),
+                MarshallerBuilder.createDefault(),
                 ReferenceCleaner.getInstance()
         );
         processor = new DynamicPropertyAwareBeanPostProcessor(propertySource);

--- a/dynamic-property-spring/src/test/java/ru/fix/dynamic/property/spring/InjectingPropertyIdBySpringTest.java
+++ b/dynamic-property-spring/src/test/java/ru/fix/dynamic/property/spring/InjectingPropertyIdBySpringTest.java
@@ -53,7 +53,7 @@ public class InjectingPropertyIdBySpringTest {
         @Bean
         public DynamicPropertySource dynamicPropertySource() {
             InMemoryPropertySource source = new InMemoryPropertySource(
-                    MarshallerBuilder.newBuilder().build(),
+                    MarshallerBuilder.createDefault(),
                     ReferenceCleaner.getInstance());
             source.set("property.city", "Biribidjan");
             return source;

--- a/dynamic-property-spring/src/test/kotlin/ru/fix/dynamic/property/spring/CloseResourcesTest.kt
+++ b/dynamic-property-spring/src/test/kotlin/ru/fix/dynamic/property/spring/CloseResourcesTest.kt
@@ -59,7 +59,7 @@ class CloseResourcesTest {
         fun serviceConfig() = ServiceConfig()
     }
 
-    object MockedPropertySource : InMemoryPropertySource(MarshallerBuilder.newBuilder().build()) {
+    object MockedPropertySource : InMemoryPropertySource(MarshallerBuilder.createDefault()) {
         val closedSubscriptions = AtomicInteger()
 
         override fun <T> createSubscription(

--- a/dynamic-property-std-source/src/test/kotlin/ru/fix/dynamic/property/std/source/FilePropertySourceTest.kt
+++ b/dynamic-property-std-source/src/test/kotlin/ru/fix/dynamic/property/std/source/FilePropertySourceTest.kt
@@ -25,7 +25,7 @@ class FilePropertySourceTest {
 
         val source = FilePropertySource(
             sourceFilePath = path,
-            marshaller = MarshallerBuilder.newBuilder().build()
+            marshaller = MarshallerBuilder.createDefault()
         )
 
         val property = SourcedProperty(source, "name", String::class.java, OptionalDefaultValue.none())
@@ -53,7 +53,7 @@ class FilePropertySourceTest {
 
         val source = FilePropertySource(
             sourceFilePath = DynamicProperty.of(f),
-            marshaller = MarshallerBuilder.newBuilder().build()
+            marshaller = MarshallerBuilder.createDefault()
         )
 
         val property = SourcedProperty(source, "name", String::class.java, OptionalDefaultValue.none())

--- a/dynamic-property-std-source/src/test/kotlin/ru/fix/dynamic/property/std/source/InMemoryPropertySourceTest.kt
+++ b/dynamic-property-std-source/src/test/kotlin/ru/fix/dynamic/property/std/source/InMemoryPropertySourceTest.kt
@@ -14,7 +14,7 @@ class InMemoryPropertySourceTest {
     @Test
     fun `register listener and change property value`() {
         val deque = Collections.synchronizedList(ArrayList<Int>())
-        val source = InMemoryPropertySource(MarshallerBuilder.newBuilder().build())
+        val source = InMemoryPropertySource(MarshallerBuilder.createDefault())
 
         val subscription = source.createSubscription(
             "foo",

--- a/dynamic-property-zk/src/test/kotlin/ru/fix/dynamic/property/zk/ZkDynamicPropertySourceTest.kt
+++ b/dynamic-property-zk/src/test/kotlin/ru/fix/dynamic/property/zk/ZkDynamicPropertySourceTest.kt
@@ -32,7 +32,7 @@ class ZkDynamicPropertySourceTest {
         source = ZkDynamicPropertySource(
             zkTestingServer.client,
             PROPERTIES_LOCATION,
-            MarshallerBuilder.newBuilder().build(),
+            MarshallerBuilder.createDefault(),
             Duration.of(1, ChronoUnit.MINUTES)
         )
     }
@@ -201,7 +201,7 @@ class ZkDynamicPropertySourceTest {
         val source = ZkDynamicPropertySource(
             zkTestingServer.createClient(),
             PROPERTIES_LOCATION,
-            MarshallerBuilder.newBuilder().build(),
+            MarshallerBuilder.createDefault(),
             Duration.of(1, ChronoUnit.MINUTES)
         )
 


### PR DESCRIPTION
- NotFoundSerializerException if all serializers return empty
- Removed defaultSerializer
- Removed throws IOException in ComposableSerializer
- JacksonSerializeException for JacksonSerializer
- createDefault() in MarshallerBuilder
- Set of serializer instead of a List

previous discussion: [link](https://github.com/ru-fix/dynamic-property/pull/30)